### PR TITLE
Change python version

### DIFF
--- a/.github/workflows/cve-bin-tool.yaml
+++ b/.github/workflows/cve-bin-tool.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '>=3.8 <3.12'
       # This second step is unnecessary but highly recommended because
       # It will cache database and saves time re-downloading it if database isn't stale.
       - name: get cached python packages

--- a/input-copy.csv
+++ b/input-copy.csv
@@ -1,0 +1,10 @@
+vendor,product,version
+plot,plotly,h5.10.0
+pocoo,jinja2,3.1.2
+aiohttp_project,aiohttp,3.8.1
+pyyaml,pyyaml,6.0
+python,requests,2.28.1
+python,urllib3,1.26.12
+skontar,cvss,2.5
+getbootstrap,bootstrap,5.2.0
+plotly,plotly.js,2.13.2


### PR DESCRIPTION
Setting a minimum Python version which, according to CVE BIN Tool documentation is 3.8.
Setting maximum Python version as 3.11. For Python 3.12 I encountered errors during installation of aiohttp.